### PR TITLE
Implementing max_rate_of_change and clamping warnings

### DIFF
--- a/apps/backAndForth/src/main/java/jp/oist/abcvlib/backandforth/MainActivity.java
+++ b/apps/backAndForth/src/main/java/jp/oist/abcvlib/backandforth/MainActivity.java
@@ -9,8 +9,8 @@ import jp.oist.abcvlib.core.AbcvlibActivity;
  * @author Christopher Buckley <a href="https://github.com/topherbuckley">...</a>
  */
 public class MainActivity extends AbcvlibActivity {
-    float speed = 0.35f;
-    float increment = 0.01f;
+    float speed = 0.0f;
+    float increment = 0.4f;
 
     protected void onCreate(Bundle savedInstanceState) {
         // Passes Android App information up to parent classes for various usages. Do not modify

--- a/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/outputs/Outputs.java
+++ b/libs/abcvlib/src/main/java/jp/oist/abcvlib/core/outputs/Outputs.java
@@ -1,10 +1,13 @@
 package jp.oist.abcvlib.core.outputs;
 
 import java.util.concurrent.TimeUnit;
+import java.lang.Math;
+
 
 import ioio.lib.api.exception.ConnectionLostException;
 import jp.oist.abcvlib.core.AbcvlibLooper;
 import jp.oist.abcvlib.core.Switches;
+import jp.oist.abcvlib.util.Logger;
 import jp.oist.abcvlib.util.ProcessPriorityThreadFactory;
 import jp.oist.abcvlib.util.ScheduledExecutorServiceWithException;
 import jp.oist.abcvlib.util.SerialCommManager;
@@ -15,6 +18,10 @@ public class Outputs {
     private final MasterController masterController;
     private final ScheduledExecutorServiceWithException threadPoolExecutor;
     private final SerialCommManager serialCommManager;
+
+    private float lastLeft = 0.0f;
+    private float lastRight = 0.0f;
+    private long lastCallTimestamp = 0;
 
     public Outputs(Switches switches, SerialCommManager serialCommManager){
         // Determine number of necessary threads.
@@ -34,11 +41,81 @@ public class Outputs {
     }
 
     /**
+     * Ideally users are not using this method but instead the default without maxChange.
+     * Please only use this if you know the implications surrounding potential motor damage.
+     * @param left speed from -1 to 1 (full speed backward vs full speed forward)
+     * @param right speed from -1 to 1 (full speed backward vs full speed forward)
+     * @param maxChange The maximum change in wheel output. Any faster than this will be clamped.
+     */
+    public void setWheelOutput(float left, float right, boolean leftBrake, boolean rightBrake, float maxChange) {
+        if (left < -1.0f) {
+            Logger.w("Outputs", "Left wheel output " + left + " is less than -1. Clamping.");
+            left = -1.0f;
+        } else if (left > 1.0f) {
+            Logger.w("Outputs", "Left wheel output " + left + " is greater than 1. Clamping.");
+            left = 1.0f;
+        }
+        if (right < -1.0f) {
+            Logger.w("Outputs", "Right wheel output " + right + " is less than -1. Clamping.");
+            right = -1.0f;
+        } else if (right > 1.0f) {
+            Logger.w("Outputs", "Right wheel output " + right + " is greater than 1. Clamping.");
+            right = 1.0f;
+        }
+
+        if (lastCallTimestamp == 0) {
+            lastCallTimestamp = System.currentTimeMillis();
+        }
+        long now = System.currentTimeMillis();
+        long dt = now - lastCallTimestamp;
+        Logger.v("Outputs", "dt: " + dt);
+
+        if (dt == 0) {
+            // To avoid division by zero
+            serialCommManager.setMotorLevels(lastLeft, lastRight, leftBrake, rightBrake);
+            return;
+        }
+
+        if (Math.abs(left - lastLeft) > maxChange) {
+            Logger.w("Outputs", "Controller attempting to change left wheel output too quickly. " +
+                    "Change: " + (left - lastLeft) + ", MaxChange: " + maxChange);
+        }
+        if (Math.abs(right - lastRight) > maxChange) {
+            Logger.w("Outputs", "Controller attempting to change right wheel output too quickly. " +
+                    "Change: " + (right - lastRight) + ", MaxChange: " + maxChange);
+        }
+
+        float newLeft = lastLeft + Math.max(-maxChange, Math.min(maxChange, left - lastLeft));
+        float newRight = lastRight + Math.max(-maxChange, Math.min(maxChange, right - lastRight));
+
+        if (newLeft < -1.0f) {
+            Logger.w("Outputs", "New left wheel output " + newLeft + " is less than -1. Clamping.");
+            newLeft = -1.0f;
+        } else if (newLeft > 1.0f) {
+            Logger.w("Outputs", "New left wheel output " + newLeft + " is greater than 1. Clamping.");
+            newLeft = 1.0f;
+        }
+
+        if (newRight < -1.0f) {
+            Logger.w("Outputs", "New right wheel output " + newRight + " is less than -1. Clamping.");
+            newRight = -1.0f;
+        } else if (newRight > 1.0f) {
+            Logger.w("Outputs", "New right wheel output " + newRight + " is greater than 1. Clamping.");
+            newRight = 1.0f;
+        }
+
+        serialCommManager.setMotorLevels(newLeft, newRight, leftBrake, rightBrake);
+        lastLeft = newLeft;
+        lastRight = newRight;
+        lastCallTimestamp = now;
+    }
+
+    /**
      * @param left speed from -1 to 1 (full speed backward vs full speed forward)
      * @param right speed from -1 to 1 (full speed backward vs full speed forward)
      */
     public void setWheelOutput(float left, float right, boolean leftBrake, boolean rightBrake) {
-        serialCommManager.setMotorLevels(left, right, leftBrake, rightBrake);
+        setWheelOutput(left, right, leftBrake, rightBrake, 0.4f);
     }
 
     public synchronized MasterController getMasterController() {


### PR DESCRIPTION
Two different definitions for setWheelOutput. The one that is used throughout the project remains the default and uses a maxChange value of 0.4 as anything larger than this seems to be too much for the motor controller to handle. This was incrementally tested and verified to be the ideal number for the current settings. This may change as loop time decreases with further optimizations. The 2nd definition of setWheelOutput allows the user to override this value of 0.4 if necessary, though not advised. 